### PR TITLE
Add tests

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:stream_data]
 ]

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,8 @@ defmodule EvalEx.MixProject do
       {:rustler, "~> 0.25.0"},
       {:rustler_precompiled, "~> 0.5.1"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:credo, "~> 1.6", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
+      {:stream_data, "~> 0.5", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "rustler": {:hex, :rustler, "0.25.0", "32526b51af7e58a740f61941bf923486ce6415a91c3934cc16c281aa201a2240", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "6b43a11a37fe79c6234d88c4102ab5dfede7a6a764dc5c7b539956cfa02f3cf4"},
   "rustler_precompiled": {:hex, :rustler_precompiled, "0.5.1", "93df423bd7b14b67dcacf994443d132d300623f80756974cac4febeab40af74a", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: true]}], "hexpm", "3f8cbc8e92eef4e1a71bf441b568b868b16a3730f63f5b803c68073017e30b13"},
+  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
   "toml": {:hex, :toml, "0.6.2", "38f445df384a17e5d382befe30e3489112a48d3ba4c459e543f748c2f25dd4d1", [:mix], [], "hexpm", "d013e45126d74c0c26a38d31f5e8e9b83ea19fc752470feb9a86071ca5a672fa"},
 }

--- a/native/evalex/src/lib.rs
+++ b/native/evalex/src/lib.rs
@@ -1,7 +1,7 @@
 mod errors;
 mod types;
 
-use evalexpr::{eval_with_context, ContextWithMutableVariables, HashMapContext};
+use evalexpr::{eval_with_context_mut, ContextWithMutableVariables, HashMapContext};
 use rustler::{Env, MapIterator, Term};
 
 #[rustler::nif]
@@ -16,7 +16,7 @@ fn eval<'a>(env: Env<'a>, string: &str, context: Term<'a>) -> Result<Term<'a>, T
             context_map.set_value(key, types::to_value(env, &v)).ok();
         });
 
-    match eval_with_context(string, &context_map) {
+    match eval_with_context_mut(string, &mut context_map) {
         Ok(value) => Ok(types::from_value(env, &value)),
         Err(err) => Err(errors::to_error_tuple(env, err)),
     }

--- a/native/evalex/src/types.rs
+++ b/native/evalex/src/types.rs
@@ -6,13 +6,14 @@ pub fn to_value<'a>(env: Env<'a>, term: &Term<'a>) -> Value {
         TermType::Binary => term
             .decode()
             .map(Value::String)
-            .expect("get_type() returned String but could not decode as string."),
+            .expect("get_type() returned Binary but could not decode as string."),
 
         TermType::Number => term
             .decode::<i64>()
             .map(Value::Int)
             .or_else(|_| term.decode::<f64>().map(Value::Float))
-            .expect("get_type() returned String but could not decode as integer or float."),
+            .expect("get_type() returned Number but could not decode as integer or float."),
+
         TermType::Atom => term
             .decode()
             .map(Value::Boolean)

--- a/test/evalex_test.exs
+++ b/test/evalex_test.exs
@@ -1,7 +1,76 @@
 defmodule EvalExTest do
   use ExUnit.Case
+  use ExUnitProperties
 
-  test "should evaluate a simple expression" do
-    assert {:ok, 3} == EvalEx.eval("1 + 2", %{})
+  describe "eval/2" do
+    test "should evaluate an expression without a context" do
+      assert {:ok, 3} == EvalEx.eval("1 + 2")
+    end
+
+    test "should evaluate an expression with a context" do
+      assert {:ok, 3} == EvalEx.eval("a + b", %{"a" => 1, "b" => 2})
+    end
+
+    test "should assing a variable" do
+      assert {:ok, 7} == EvalEx.eval("c = 4; a + b + c", %{"a" => 1, "b" => 2})
+    end
+
+    test "should return an error if a variable does not exist" do
+      assert {:error,
+              {:variable_identifier_not_found,
+               "Variable identifier is not bound to anything by context: \"b\"."}} ==
+               EvalEx.eval("a + b", %{"a" => 1})
+    end
+  end
+
+  describe "type conversion" do
+    property "should convert integer() to Integer and Integer to integer()" do
+      check all int <- integer() do
+        assert {:ok, result} = EvalEx.eval("a", %{"a" => int})
+        assert int == result
+        assert is_integer(result)
+      end
+    end
+
+    property "should convert float() to Float and Float to float()" do
+      check all float <- float() do
+        assert {:ok, result} = EvalEx.eval("a", %{"a" => float})
+        assert float == result
+        assert is_float(result)
+      end
+    end
+
+    property "should convert boolean() to Bool and Bool to boolean()" do
+      check all bool <- boolean() do
+        assert {:ok, result} = EvalEx.eval("a", %{"a" => bool})
+        assert bool == result
+        assert is_boolean(result)
+      end
+    end
+
+    property "should convert tuple() to List and List to list()" do
+      check all tuple <- tuple({integer(), string(:ascii)}) do
+        assert {:ok, result} = EvalEx.eval("a", %{"a" => tuple})
+        assert Tuple.to_list(tuple) == result
+        assert is_list(result)
+      end
+    end
+
+    property "should convert list() to List and List to list()" do
+      check all list <- list_of(string(:ascii)) do
+        assert {:ok, result} = EvalEx.eval("a", %{"a" => list})
+        assert list == result
+        assert is_list(list)
+      end
+    end
+
+    property "should convert String.t() to String and String to String.t()" do
+      check all str1 <- string(:ascii),
+                str2 <- string(:printable) do
+        assert {:ok, result} = EvalEx.eval("a + b", %{"a" => str1, "b" => str2})
+        assert str1 <> str2 == result
+        assert is_binary(result)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add `eval/2` tests and conversion property testing.

Switches to `eval_with_context_mut` to allow variable assignment in expressions.